### PR TITLE
Mount slave flag configuration

### DIFF
--- a/files/etc/systemd/system/docker.service.d/mountflags-slave.conf
+++ b/files/etc/systemd/system/docker.service.d/mountflags-slave.conf
@@ -1,0 +1,3 @@
+[Service]
+# MountFlags "slave" helps to prevent "device busy" errors on RHEL/CentOS 7.3 kernels
+MountFlags=slave

--- a/tasks/main-CentOS.yml
+++ b/tasks/main-CentOS.yml
@@ -40,4 +40,7 @@
 - include: main-Storage.yml
   when: docker_setup_devicemapper == true
 
+- include: main-Mountflags.yml
+  when: docker_setup_mountslaveflag == true
+
 - include: main-Generic.yml

--- a/tasks/main-CentOS.yml
+++ b/tasks/main-CentOS.yml
@@ -41,6 +41,6 @@
   when: docker_setup_devicemapper == true
 
 - include: main-Mountflags.yml
-  when: docker_setup_mountslaveflag == true
+  when: "{{ ansible_kernel | version_compare('4', '<') }}"
 
 - include: main-Generic.yml

--- a/tasks/main-Mountflags.yml
+++ b/tasks/main-Mountflags.yml
@@ -1,0 +1,13 @@
+- name: Ensure /etc/systemd/system/docker.service.d directory exists
+  file: 
+    path: /etc/systemd/system/docker.service.d
+    state: directory
+    mode: 0755
+  become: yes
+
+- name: Copy systemd drop-in for Docker Mount Flags slave configuration
+  copy:
+    src: files/etc/systemd/system/docker.service.d/mountflags-slave.conf
+    dest: /etc/systemd/system/docker.service.d/mountflags-slave.conf
+  become: yes
+


### PR DESCRIPTION
MountFlags "slave" helps to prevent "device busy" errors on RHEL/CentOS 7.3 kernels

https://github.com/moby/moby/issues/34198