### PR TITLE
add docker_enable_mount_flag_fix for explicit toggling of MountFlags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.retry
 .vscode/
 *.vdi
+/.project

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ docker_bug_usermod: false
 docker_enable_audit: false
 # Enable Docker CE Edge
 docker_enable_ce_edge: false
+# Set `MountFlags=slave`
+#  https://github.com/haxorof/ansible-role-docker-ce/issues/34
+docker_enable_mount_flag_fix: yes
 # Always ensure latest version of Docker CE
 docker_latest_version: true
 # Docker package to install. Change this if you want a specific version of Docker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,9 @@ docker_bug_usermod: false
 docker_enable_audit: false
 # Enable Docker CE Edge
 docker_enable_ce_edge: false
+# Set `MountFlags=slave`
+#  https://github.com/haxorof/ansible-role-docker-ce/issues/34
+docker_enable_mount_flag_fix: yes
 # Always ensure latest version of Docker CE
 docker_latest_version: true
 # Docker package to install. Change this if you want a specific version of Docker

--- a/tasks/config-check.yml
+++ b/tasks/config-check.yml
@@ -1,0 +1,11 @@
+---
+- name: Fail if MountFlags and live-restore are set
+  fail:
+    msg: >
+      Setting both `MountFlags=slave` (docker_enable_mount_flag_fix: true)
+      and `live-restore=true` (docker_daemon_config['live-restore']: true)
+      triggers a bug (https://github.com/moby/moby/issues/35873). For now,
+      don't use both.
+  when: docker_enable_mount_flag_fix
+        and (docker_daemon_config['live-restore'] is defined
+        and docker_daemon_config['live-restore'])

--- a/tasks/kernel-3-mount-fixes.yml
+++ b/tasks/kernel-3-mount-fixes.yml
@@ -24,4 +24,11 @@
     src: files/etc/systemd/system/docker.service.d/mountflags-slave.conf
     dest: /etc/systemd/system/docker.service.d/mountflags-slave.conf
   become: yes
-
+  when: docker_enable_mount_flag_fix
+  
+- name: Remove systemd drop-in for Docker Mount Flags slave configuration
+  file:
+    path: /etc/systemd/system/docker.service.d/mountflags-slave.conf
+    state: absent
+  become: yes
+  when: not docker_enable_mount_flag_fix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,8 @@
     docker_os_dist == "Linux Mint" and
     docker_os_dist_major_version == "18"
 
+- include: config-check.yml
+
 - include: distribution-check.yml
   when:
     docker_os_dist_check | bool


### PR DESCRIPTION
#34 (and a bit of #33)

* Adds `docker_enable_mount_flag_fix` (default to `true`)
* Adds error when both `docker_enable_mount_flag_fix: true` and `docker_daemon_config['live-restore']: true`

For (at least) some OSes/versions, it may also make sense to deprecate `docker_enable_mount_flag_fix` or default the behavior to false. (Not sure.)