### PR TITLE
Python3 forward compatibility

### DIFF
--- a/templates/docker-envs.j2
+++ b/templates/docker-envs.j2
@@ -1,4 +1,4 @@
 # {{ ansible_managed }}
-{% for key, value in docker_envs.iteritems() %}
+{% for key, value in docker_envs.items()|list %}
 {{ key }}="{{ value }}"
 {% endfor %}


### PR DESCRIPTION
Python3 does not implement iteritems, but uses `items` and throwing filter `|list` allow compatibility for python2 and 3.