### PR TITLE
Identify systemd support even in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
   become: true
   shell: "ps -p1 | grep systemd 1>/dev/null && echo systemd || echo upstart"
   changed_when: no
+  check_mode: no
   register: _determine_systemd_usage
 
 - name: Set fact to indicate systemd is not used


### PR DESCRIPTION
The “Determine usage of systemd” only collects data and makes no change. When in check mode, it will currently leads to a failure of the “Set fact to indicate systemd is not used” task because we do not have the info.

As it makes no change, it is safe to execute it also when in check mode, which then allows executing the role when in check mode.

Note: this obviously will only effect check mode executions during updates as check mode will most likely fail on previous steps on first run