### PR TITLE
Fix python3 reference in tasks/postinstall.yml

### DIFF
--- a/tasks/postinstall.yml
+++ b/tasks/postinstall.yml
@@ -51,7 +51,7 @@
 
     - name: Set fact to install Python 3 PiP and build dependencies
       set_fact:
-        _docker_additional_packages_os: "{{ _docker_additional_packages_os + [docker_pip3_package] + [docker_python2_build_os_pkgs[_docker_os_dist]] }}"
+        _docker_additional_packages_os: "{{ _docker_additional_packages_os + [docker_pip3_package] + [docker_python3_build_os_pkgs[_docker_os_dist]] }}"
       when:
         - _docker_python3 | bool
         - _docker_pip_cmd.rc != 0


### PR DESCRIPTION
The python postinstall script used the python2 package list in the python3 task.
On CentOS 8, the deploy fails, reporting that it cannot find the python2 package.
Changed it to the python3 variable, and deploy works fine.