### PR TITLE
enforce docker restart before plugins setup

### DIFF
--- a/tasks/configure-docker/configure-docker-plugins.yml
+++ b/tasks/configure-docker/configure-docker-plugins.yml
@@ -14,6 +14,12 @@
   tags:
     - skip_ansible_lint
 
+- name: Force docker restart
+  become: yes
+  service:
+    name: docker
+    state: restarted
+
 - name: Install Docker plugins
   become: yes
   shell: "(docker plugin install --grant-all-permissions --alias {{ item.alias | default(item.name) }} {{ item.name }} \


### PR DESCRIPTION
It fixes the issue when ansible successfully installs plugins but fails to run the last `restart docker` handler in the end.