### PR TITLE
Fix broken Linux Mint 19 + 20

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,22 @@
   when: _docker_os_dist == "Linux Mint" and _docker_os_dist_major_version | int == 18
   tags: ["install", "configure", "postinstall", "docker_install", "docker_configure", "docker_postinstall"]
 
+- name: Reinterpret distribution facts for Linux Mint 19
+  set_fact:
+    _docker_os_dist: "Ubuntu"
+    _docker_os_dist_release: "bionic"
+    _docker_os_dist_major_version: 18
+  when: _docker_os_dist == "Linux Mint" and _docker_os_dist_major_version | int == 19
+  tags: ["install", "configure", "postinstall", "docker_install", "docker_configure", "docker_postinstall"]
+
+- name: Reinterpret distribution facts for Linux Mint 20
+  set_fact:
+    _docker_os_dist: "Ubuntu"
+    _docker_os_dist_release: "focal"
+    _docker_os_dist_major_version: 20
+  when: _docker_os_dist == "Linux Mint" and _docker_os_dist_major_version | int == 20
+  tags: ["install", "configure", "postinstall", "docker_install", "docker_configure", "docker_postinstall"]
+
 - name: Reinterpret distribution facts for Debian 10 (Buster) due to bug
   set_fact:
     _docker_os_dist: "Debian"

--- a/tasks/setup-repository-Debian.yml
+++ b/tasks/setup-repository-Debian.yml
@@ -71,7 +71,7 @@
   copy:
     content: >
       deb [arch={{ _docker_os_arch|lower }}] https://download.docker.com/linux/{{ _docker_os_dist|lower }}
-      {{ ansible_lsb.codename }} {{ _docker_enable_channels | join(' ') }}
+      {{ _docker_os_dist_release }} {{ _docker_enable_channels | join(' ') }}
     dest: /etc/apt/sources.list.d/docker-ce.list
     owner: root
     group: root


### PR DESCRIPTION
Hello! [Linux Mint](https://linuxmint.com/) user is here

## Problem

I'm using Linux Mint 20.2 (Uma). And found that role is not working correctly for my Linux Mint host:

```bash
TASK [vendor/roles/docker : Fail if this role does not support the distribution] ***
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Distribution Linux Mint is not supported by this role!"}
```

I thought it's weird because Mint is listed in repo's readme.

## Proposed solution

After quick debugging I found 2 issues:
1. Linux Mint 19 & 20 are not mapped to Ubuntu distros on facts gathering step. So i've added them according to ubuntu versions Mint based on:
    - Linux Mint 20: Based on 20.04 (focal)
    - Linux Mint 19: Based on 18.04 (bionic)

    ```patch
    --- a/tasks/main.yml
    +++ b/tasks/main.yml
    @@ -24,6 +24,22 @@
    +- name: Reinterpret distribution facts for Linux Mint 19
    +  set_fact:
    +    _docker_os_dist: "Ubuntu"
    +    _docker_os_dist_release: "bionic"
    +    _docker_os_dist_major_version: 18
    +  when: _docker_os_dist == "Linux Mint" and _docker_os_dist_major_version | int == 19
    +  tags: ["install", "configure", "postinstall", "docker_install", "docker_configure", "docker_postinstall"]
    +
    +- name: Reinterpret distribution facts for Linux Mint 20
    +  set_fact:
    +    _docker_os_dist: "Ubuntu"
    +    _docker_os_dist_release: "focal"
    +    _docker_os_dist_major_version: 20
    +  when: _docker_os_dist == "Linux Mint" and _docker_os_dist_major_version | int == 20
    +  tags: ["install", "configure", "postinstall", "docker_install", "docker_configure", "docker_postinstall"]
    +
     ```



2. Once i've added mapping, I found that repo was added with ubuntu distro, but still with mint's codename:
    ```
    deb [arch=amd64] https://download.docker.com/linux/ubuntu uma stable
    ``` 

    Debian repo uses `ansible_lsb.codename` for distro code name, but not `_docker_os_dist_release` from facts gathered earlier. So i've replaced it:

    ```patch
    --- a/tasks/setup-repository-Debian.yml
    +++ b/tasks/setup-repository-Debian.yml
    @@ -71,7 +71,7 @@
      copy:
        content: >
          deb [arch={{ _docker_os_arch|lower }}] https://download.docker.com/linux/{{ _docker_os_dist|lower }}
    -      {{ ansible_lsb.codename }} {{ _docker_enable_channels | join(' ') }}
    +      {{ _docker_os_dist_release }} {{ _docker_enable_channels | join(' ') }}
        dest: /etc/apt/sources.list.d/docker-ce.list
        owner: root
        group: root
    ```

And voila, everything works!