### PR TITLE
Better support for CentOS Stream 8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,12 @@
     _docker_python3: "{{ ansible_python_version is version('3', '>=') }}"
   tags: ["install", "configure", "postinstall", "docker_install", "docker_configure", "docker_postinstall"]
 
+- name: Override ansible_distribution_file_variety for CentOS 8
+  set_fact:
+    ansible_distribution_file_variety: "RedHat"
+  when: ansible_distribution_file_variety == "CentOS"
+  tags: ["install", "configure", "postinstall", "docker_install", "docker_configure", "docker_postinstall"]
+
 - name: Reinterpret distribution facts for Linux Mint
   set_fact:
     _docker_os_dist: "Ubuntu"


### PR DESCRIPTION
CentOS Stream 8 is now recognized as `CentOS` and not `RedHat` anymore, so in order to load the correct files, this override add support for it withoud creating any new file or variable since everything else remain the same.