### PR TITLE
Add Linux Mint 21 support.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,9 @@ docker_x_mint_ubuntu_mapping:
       20:
         release: "focal"
         major_version: 20
+      21:
+        release: "jammy"
+        major_version: 22
 
 # Change OS service manager. Can be used to work around issues related
 # to Ubuntu on WSL2 or similar.


### PR DESCRIPTION
Linux Mint 21 “Vanessa” released:
- Major version of Mint: `21`
- Based on: `Ubuntu 22.04 (jammy)`

This PR adds configuration mapping for the correct detection of the Ubuntu codename used in the Linux mint distro.