### PR TITLE
docker_sdk: define docker>=5 and docker-compose>=1.29 when python >= 3

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -93,17 +93,17 @@ docker_predefined_packages_os: []
 docker_predefined_packages_pip:
   RedHat:
     sdk:
-      - docker{{'<5' if ansible_python_version is version('3', '<') }}
+      - docker{{'<5' if ansible_python_version is version('3', '<') else '>=5' }}
     compose:
-      - docker-compose{{'<1.29' if ansible_python_version is version('3', '<') }}
+      - docker-compose{{'<1.29' if ansible_python_version is version('3', '<') else '>=1.29' }}
     stack:
       - jsondiff
       - pyyaml
   Debian:
     sdk:
-      - docker{{'<5' if ansible_python_version is version('3', '<') }}
+      - docker{{'<5' if ansible_python_version is version('3', '<') else '>=5' }}
     compose:
-      - docker-compose{{'<1.29' if ansible_python_version is version('3', '<') }}
+      - docker-compose{{'<1.29' if ansible_python_version is version('3', '<') else '>=1.29' }}
     stack:
       - jsondiff
       - pyyaml


### PR DESCRIPTION
Fix: the inline if-expression on line 1 evaluated to false and no else section was defined.

Signed-off-by: jialeie <jialei.feng@intel.com>