### PR TITLE
Interpolation to determine channel does not work in ansible-core 2.16

### DIFF
--- a/tasks/setup-repository-Debian.yml
+++ b/tasks/setup-repository-Debian.yml
@@ -60,7 +60,7 @@
     _docker_enable_channels: "{{ docker_channels | intersect(_docker_merged_channels) }}"
   vars:
     _docker_mandatory_channel: []
-    _docker_merged_channels: "{{ _docker_mandatory_channel }} + [ '{{ docker_channel }}' ]"
+    _docker_merged_channels: "{{ _docker_mandatory_channel + [docker_channel] }}"
 
 - name: Add Docker CE repository with correct channels (Ubuntu/Debian)
   become: true

--- a/tasks/setup-repository-RedHat.yml
+++ b/tasks/setup-repository-RedHat.yml
@@ -26,7 +26,7 @@
     _docker_enable_channels: "{{ docker_channels | intersect(_docker_merged_channels) }}"
   vars:
     _docker_mandatory_channel: []
-    _docker_merged_channels: "{{ _docker_mandatory_channel }} + [ '{{ docker_channel }}' ]"
+    _docker_merged_channels: "{{ _docker_mandatory_channel + [docker_channel] }}"
 
 - name: Add Docker CE repository
   when:


### PR DESCRIPTION
I don't know how but this started not working on my VM today, the `_docker_enable_channels` fact is always empty.
Looking at the code it seems uncorrectly formatted indeed, how did it work before ?