### PR TITLE
Add support for arm64

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     _docker_os_dist_release: "{{ ansible_distribution_release }}"
     _docker_os_dist_major_version: "{{ ansible_distribution_major_version }}"
     _docker_os_dist_file_varity: "{{ ansible_distribution_file_variety }}"
-    _docker_os_arch: "amd64"
+    _docker_os_arch: "{{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }}"
     _docker_os_dist_check: yes
     _docker_python3: "{{ ansible_python_version is version('3', '>=') }}"
   tags: ["install", "configure", "postinstall", "docker_install", "docker_configure", "docker_postinstall"]


### PR DESCRIPTION
I noticed this was failing on my ARM64-based Ubuntu VMs.

Making this change allowed the entire role to execute correctly.

For what it's worth, this is the way it's done in **geerlingguy/ansible-role-docker** ([link](https://github.com/geerlingguy/ansible-role-docker/blob/master/defaults/main.yml#L40)).