### PR TITLE
Support Fedora 41

### DIFF
--- a/tasks/setup-repository-RedHat.yml
+++ b/tasks/setup-repository-RedHat.yml
@@ -66,7 +66,7 @@
 
 - name: Disable Docker CE repository channels
   become: true
-  ansible.builtin.shell: "{{ docker_cmd_enable_disable_repo[_docker_os_dist_file_varity] }}"
+  ansible.builtin.shell: "{{ docker_cmd_enable_disable_repo[_docker_os_dist] }}"
   loop: "{{ _docker_disable_channels }}"
   changed_when: false
   vars:
@@ -76,7 +76,7 @@
 
 - name: Enable Docker CE repository channels
   become: true
-  ansible.builtin.shell: "{{ docker_cmd_enable_disable_repo[_docker_os_dist_file_varity] }}"
+  ansible.builtin.shell: "{{ docker_cmd_enable_disable_repo[_docker_os_dist] }}"
   loop: "{{ _docker_enable_channels }}"
   changed_when: false
   vars:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -26,6 +26,7 @@ docker_cmd_enable_disable_repo:
     || yum-config-manager --{{ (_item_enabled == true) | ternary('enable', 'disable') }} docker-ce-{{ item }}
   Fedora: >
     dnf config-manager --set-{{ (_item_enabled == true) | ternary('enabled', 'disabled') }} docker-ce-{{ item }}
+    || dnf config-manager setopt docker-ce-{{item}}.enabled={{ (_item_enabled == true) | ternary('1', '0') }}
 
 docker_cmd_update_repo_cache:
   RedHat: type dnf && dnf makecache || yum makecache

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,6 +24,8 @@ docker_cmd_enable_disable_repo:
   RedHat: >
     type dnf && dnf config-manager --set-{{ (_item_enabled == true) | ternary('enabled', 'disabled') }} docker-ce-{{ item }}
     || yum-config-manager --{{ (_item_enabled == true) | ternary('enable', 'disable') }} docker-ce-{{ item }}
+  Fedora: >
+    dnf config-manager --set-{{ (_item_enabled == true) | ternary('enabled', 'disabled') }} docker-ce-{{ item }}
 
 docker_cmd_update_repo_cache:
   RedHat: type dnf && dnf makecache || yum makecache

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -21,12 +21,21 @@ docker_channels:
   - test
 
 docker_cmd_enable_disable_repo:
-  RedHat: >
+  AlmaLinux: >
+    type dnf && dnf config-manager --set-{{ (_item_enabled == true) | ternary('enabled', 'disabled') }} docker-ce-{{ item }}
+    || yum-config-manager --{{ (_item_enabled == true) | ternary('enable', 'disable') }} docker-ce-{{ item }}
+  CentOS: >
     type dnf && dnf config-manager --set-{{ (_item_enabled == true) | ternary('enabled', 'disabled') }} docker-ce-{{ item }}
     || yum-config-manager --{{ (_item_enabled == true) | ternary('enable', 'disable') }} docker-ce-{{ item }}
   Fedora: >
     dnf config-manager --set-{{ (_item_enabled == true) | ternary('enabled', 'disabled') }} docker-ce-{{ item }}
     || dnf config-manager setopt docker-ce-{{item}}.enabled={{ (_item_enabled == true) | ternary('1', '0') }}
+  RedHat: >
+    type dnf && dnf config-manager --set-{{ (_item_enabled == true) | ternary('enabled', 'disabled') }} docker-ce-{{ item }}
+    || yum-config-manager --{{ (_item_enabled == true) | ternary('enable', 'disable') }} docker-ce-{{ item }}
+  Rocky: >
+    type dnf && dnf config-manager --set-{{ (_item_enabled == true) | ternary('enabled', 'disabled') }} docker-ce-{{ item }}
+    || yum-config-manager --{{ (_item_enabled == true) | ternary('enable', 'disable') }} docker-ce-{{ item }}
 
 docker_cmd_update_repo_cache:
   RedHat: type dnf && dnf makecache || yum makecache


### PR DESCRIPTION
Fedora 41 has a new version of dnf (dnf5), which uses new options and no longer has a separate yum-config-manager command. 

This patch fixes the role for Fedora 41, by explicitly adding dnf5 support with the new options, while keeping Alma, Rocky, RHEL and CentOS and the previous default of trying dnf and falling back to yum for repo management.