### PR TITLE
Add support to Ubuntu 25.04 and above

### DIFF
--- a/tasks/setup-repository-Debian.yml
+++ b/tasks/setup-repository-Debian.yml
@@ -40,12 +40,24 @@
 - name: Add Docker official GPG key
   when:
     - docker_network_access | bool
-    - (_docker_os_dist == "Ubuntu" and _docker_os_dist_major_version | int > 14) or
+    - (_docker_os_dist == "Ubuntu" and _docker_os_dist_major_version | int > 14 and _docker_os_dist_major_version | int < 25) or
       (_docker_os_dist == "Debian" and _docker_os_dist_major_version | int > 7)
   become: true
   ansible.builtin.apt_key:
     url: https://download.docker.com/linux/{{ _docker_os_dist | lower }}/gpg
     state: present
+  register: _pkg_result
+  until: _pkg_result is succeeded
+
+- name: Download Docker GPG key
+  when:
+    - docker_network_access | bool
+    - (_docker_os_dist == "Ubuntu" and _docker_os_dist_major_version | int > 24)
+  become: true
+  ansible.builtin.get_url:
+    url: https://download.docker.com/linux/{{ _docker_os_dist | lower }}/gpg
+    dest: /etc/apt/keyrings/docker.asc
+    mode: 'u=rw,g=r,o=r'
   register: _pkg_result
   until: _pkg_result is succeeded
 

--- a/tasks/setup-repository-Debian.yml
+++ b/tasks/setup-repository-Debian.yml
@@ -57,7 +57,7 @@
   ansible.builtin.get_url:
     url: https://download.docker.com/linux/{{ _docker_os_dist | lower }}/gpg
     dest: /etc/apt/keyrings/docker.asc
-    mode: 'u=rw,g=r,o=r'
+    mode: '0644'
   register: _pkg_result
   until: _pkg_result is succeeded
 
@@ -70,9 +70,25 @@
 
 - name: Add Docker CE repository with correct channels (Ubuntu/Debian)
   become: true
+  when:
+    - (_docker_os_dist == "Ubuntu" and _docker_os_dist_major_version | int > 14 and _docker_os_dist_major_version | int < 25) or
+      (_docker_os_dist == "Debian" and _docker_os_dist_major_version | int > 7)
   ansible.builtin.copy:
     content: >
       deb [arch={{ _docker_os_arch | lower }}] https://download.docker.com/linux/{{ _docker_os_dist | lower }}
+      {{ _docker_os_dist_release }} {{ _docker_enable_channels | join(' ') }}
+    dest: /etc/apt/sources.list.d/docker-ce.list
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Add Docker CE repository with correct channels (Ubuntu > 24)
+  become: true
+  when:
+    - (_docker_os_dist == "Ubuntu" and _docker_os_dist_major_version | int > 24)
+  ansible.builtin.copy:
+    content: >
+      deb [arch={{ _docker_os_arch | lower }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ _docker_os_dist | lower }}
       {{ _docker_os_dist_release }} {{ _docker_enable_channels | join(' ') }}
     dest: /etc/apt/sources.list.d/docker-ce.list
     owner: root


### PR DESCRIPTION
Ubuntu 25.04 and newer have removed the legacy apt-key command and now require repository GPG keys to be stored in /etc/apt/keyrings/.
This PR implements the official Docker installation procedure (see [https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository ](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository))